### PR TITLE
First configuration for glossary

### DIFF
--- a/esteren/tiddlers/$__.data_books.tid
+++ b/esteren/tiddlers/$__.data_books.tid
@@ -1,0 +1,15 @@
+created: 20150830174323723
+modified: 20150830174734471
+tags: 
+title: $:/.data/books
+type: application/x-tiddler-dictionary
+
+book_0:[[Livre 0 – Prologue]]
+book_1:[[Livre 1 – Univers]]
+book_2:[[Livre 2 – Voyages]]
+book_3-1:[[Livre 3 – Dearg, épisode 1]]
+book_3-2:[[Livre 3 – Dearg, épisode 2]]
+book_3-3:[[Livre 3 – Dearg, épisode 3]]
+book_mln:[[Thema "Manuel de la Lune Noire"]]
+book_mt:[[Thema "Le Monastère de Tuath"]]
+book_occ:[[Thema "Occultisme"]]

--- a/esteren/tiddlers/$__.images_new-term-button.tid
+++ b/esteren/tiddlers/$__.images_new-term-button.tid
@@ -1,0 +1,15 @@
+created: 20150830170426258
+modified: 20150830171407016
+tags: $:/tags/Image
+title: $:/.images/new-term-button
+type: text/vnd.tiddlywiki
+
+<svg class="ec-image-new-term-button tc-image-button" viewBox="0 0 128 128" width="22pt" height="22pt">
+    <g fill-rule="evenodd">
+        <rect x="0" y="16" width="96" height="16" rx="8"></rect>
+        <rect x="0" y="46" width="96" height="16" rx="8"></rect>
+        <rect x="0" y="76" width="96" height="16" rx="8"></rect>
+        <rect x="96" y="80" width="16" height="48" rx="8"></rect>
+        <rect x="80" y="96" width="48" height="16" rx="8"></rect>
+    </g>
+</svg>

--- a/esteren/tiddlers/$__.skeletons_glossary-term.tid
+++ b/esteren/tiddlers/$__.skeletons_glossary-term.tid
@@ -1,0 +1,6 @@
+category: glossary
+created: 20150830171647126
+modified: 20150830172355484
+title: $:/.skeletons/glossary-term
+type: text/vnd.tiddlywiki
+

--- a/esteren/tiddlers/$__.ui_Buttons_new-glossary-term.tid
+++ b/esteren/tiddlers/$__.ui_Buttons_new-glossary-term.tid
@@ -1,0 +1,11 @@
+caption: {{$:/.images/new-term-button}} nouveau terme
+created: 20150830165251197
+description: Créer un nouveau terme du glossaire
+modified: 20150830173130776
+title: $:/.ui/Buttons/new-glossary-term
+type: text/vnd.tiddlywiki
+
+<$button tooltip={{$:/.ui/Buttons/new-glossary-term!!description}} aria-label="nouveau terme" class=<<tv-config-toolbar-class>>>
+<$action-sendmessage $message="tm-new-tiddler" $param="$:/.skeletons/glossary-term" title="(nom du terme)" tags="divers"/>
+{{$:/.ui/Buttons/new-glossary-term!!caption}}
+</$button>

--- a/esteren/tiddlers/$__.ui_SideBar_Contents.tid
+++ b/esteren/tiddlers/$__.ui_SideBar_Contents.tid
@@ -2,13 +2,17 @@ caption: {{$:/language/SideBar/Contents/Caption}}
 created: 20140809114010378
 list: 
 list-before: $:/core/ui/SideBar/Open
-modified: 20150829221528550
+modified: 20150830174910891
 tags: $:/tags/SideBar
 title: $:/.ui/SideBar/Contents
 type: text/vnd.tiddlywiki
 
 <div class="tc-table-of-contents">
 
+!! Glossaire :
 <<toc-selective-expandable 'toc'>>
+
+!! Livres :
+<<toc-selective-expandable 'livres'>>
 
 </div>

--- a/esteren/tiddlers/$__.ui_SideBar_Contents.tid
+++ b/esteren/tiddlers/$__.ui_SideBar_Contents.tid
@@ -1,0 +1,14 @@
+caption: {{$:/language/SideBar/Contents/Caption}}
+created: 20140809114010378
+list: 
+list-before: $:/core/ui/SideBar/Open
+modified: 20150829221528550
+tags: $:/tags/SideBar
+title: $:/.ui/SideBar/Contents
+type: text/vnd.tiddlywiki
+
+<div class="tc-table-of-contents">
+
+<<toc-selective-expandable 'toc'>>
+
+</div>

--- a/esteren/tiddlers/$__.ui_SideBar_Creation.tid
+++ b/esteren/tiddlers/$__.ui_SideBar_Creation.tid
@@ -1,0 +1,16 @@
+caption: Création
+created: 20150830164717553
+list: 
+list-before: $:/core/ui/SideBar/More
+modified: 20150830172826346
+tags: $:/tags/SideBar
+title: $:/.ui/SideBar/Creation
+type: text/vnd.tiddlywiki
+
+"""
+Sandox ([[WikiText|Sandbox (WikiText)]] or [[Markdown|Sandbox (Markdown)]])
+"""
+
+<div class="tc-page-controls">
+<$transclude tiddler="$:/.ui/Buttons/new-glossary-term" mode="inline"/>
+</div>

--- a/esteren/tiddlers/$__.ui_ViewTemplate_glossary-infos.tid
+++ b/esteren/tiddlers/$__.ui_ViewTemplate_glossary-infos.tid
@@ -1,0 +1,20 @@
+created: 20150830175134729
+list-before: $:/core/ui/ViewTemplate/subtitle
+modified: 20150830180229260
+tags: $:/tags/ViewTemplate
+title: $:/.ui/ViewTemplate/glossary-infos
+type: text/vnd.tiddlywiki
+
+<$list filter="[all[current]regexp:category[glossary]]">
+  <div class="ec-glossary-infos">
+    <$list filter="[all[current]has[pronunciation]]">
+      __Prononciation__ : {{!!pronunciation}}
+    </$list>
+    <$list filter="[all[current]has[plural]]">
+      __Pluriel__ : {{!!plural}}
+    </$list>
+    <$list filter="[all[current]has[meaning]]">
+      __Signification en langue ancienne__ : {{!!meaning}}
+    </$list>
+  </div>
+</$list>

--- a/esteren/tiddlers/$__.ui_ViewTemplate_references.tid
+++ b/esteren/tiddlers/$__.ui_ViewTemplate_references.tid
@@ -1,0 +1,21 @@
+created: 20150830180247851
+list-after: $:/core/ui/ViewTemplate/body
+modified: 20150830181352219
+tags: $:/tags/ViewTemplate
+title: $:/.ui/ViewTemplate/references
+type: text/vnd.tiddlywiki
+
+<$list filter="[all[current]regexp:category[glossary]]">
+  <div class="ec-references">
+
+!! Références
+
+    <ul>
+      <$list filter="[all[current]fields[]prefix[book_]sort[title]]" variable="currentField">
+        <li>
+          <$transclude tiddler="$:/.data/books" index=<<currentField>>/> : <$transclude field=<<currentField>>/>
+        </li>
+      </$list>
+    </ul>
+  </div>
+</$list>

--- a/esteren/tiddlers/$__DefaultTiddlers.tid
+++ b/esteren/tiddlers/$__DefaultTiddlers.tid
@@ -1,6 +1,6 @@
 created: 20150829134136293
-modified: 20150829134138231
+modified: 20150829222301664
 title: $:/DefaultTiddlers
 type: text/vnd.tiddlywiki
 
-Sandbox
+[[Sandbox (Markdown)]]

--- a/esteren/tiddlers/$__StoryList.tid
+++ b/esteren/tiddlers/$__StoryList.tid
@@ -1,5 +1,5 @@
-created: 20150829222404852
-list: [[Sandbox (Markdown)]]
+created: 20150830181650292
+list: 
 title: $:/StoryList
 type: text/vnd.tiddlywiki
 

--- a/esteren/tiddlers/$__StoryList.tid
+++ b/esteren/tiddlers/$__StoryList.tid
@@ -1,5 +1,5 @@
-created: 20150829141435252
-list: Sandbox
+created: 20150829222404852
+list: [[Sandbox (Markdown)]]
 title: $:/StoryList
 type: text/vnd.tiddlywiki
 

--- a/esteren/tiddlers/$__config_PageControlButtons_Visibility_$__core_ui_Buttons_encryption.tid
+++ b/esteren/tiddlers/$__config_PageControlButtons_Visibility_$__core_ui_Buttons_encryption.tid
@@ -1,6 +1,0 @@
-created: 20150829135132362
-modified: 20150829135131295
-title: $:/config/PageControlButtons/Visibility/$:/core/ui/Buttons/encryption
-type: text/vnd.tiddlywiki
-
-show

--- a/esteren/tiddlers/$__config_PageControlButtons_Visibility_$__core_ui_Buttons_full-screen.tid
+++ b/esteren/tiddlers/$__config_PageControlButtons_Visibility_$__core_ui_Buttons_full-screen.tid
@@ -1,6 +1,0 @@
-created: 20150829135138832
-modified: 20150829135137766
-title: $:/config/PageControlButtons/Visibility/$:/core/ui/Buttons/full-screen
-type: text/vnd.tiddlywiki
-
-hide

--- a/esteren/tiddlers/$__config_PageControlButtons_Visibility_$__core_ui_Buttons_language.tid
+++ b/esteren/tiddlers/$__config_PageControlButtons_Visibility_$__core_ui_Buttons_language.tid
@@ -1,6 +1,0 @@
-created: 20150829134103282
-modified: 20150829135148284
-title: $:/config/PageControlButtons/Visibility/$:/core/ui/Buttons/language
-type: text/vnd.tiddlywiki
-
-hide

--- a/esteren/tiddlers/$__config_PageControlButtons_Visibility_$__core_ui_Buttons_storyview.tid
+++ b/esteren/tiddlers/$__config_PageControlButtons_Visibility_$__core_ui_Buttons_storyview.tid
@@ -1,6 +1,0 @@
-created: 20150829135129264
-modified: 20150829135128203
-title: $:/config/PageControlButtons/Visibility/$:/core/ui/Buttons/storyview
-type: text/vnd.tiddlywiki
-
-hide

--- a/esteren/tiddlers/$__config_Tiddlers_TitleLinks.tid
+++ b/esteren/tiddlers/$__config_Tiddlers_TitleLinks.tid
@@ -1,6 +1,0 @@
-created: 20150829135352019
-modified: 20150829135350943
-title: $:/config/Tiddlers/TitleLinks
-type: text/vnd.tiddlywiki
-
-no

--- a/esteren/tiddlers/$__config_Toolbar_Text.tid
+++ b/esteren/tiddlers/$__config_Toolbar_Text.tid
@@ -1,6 +1,0 @@
-created: 20150829135402351
-modified: 20150829135401154
-title: $:/config/Toolbar/Text
-type: text/vnd.tiddlywiki
-
-no

--- a/esteren/tiddlers/$__core_ui_SideBar_Tools.tid
+++ b/esteren/tiddlers/$__core_ui_SideBar_Tools.tid
@@ -1,0 +1,35 @@
+caption: {{$:/language/SideBar/Tools/Caption}}
+created: 20150830072911457
+modified: 20150830072911457
+tags: $:/tags/MoreSideBar
+title: $:/core/ui/SideBar/Tools
+type: text/vnd.tiddlywiki
+
+\define lingo-base() $:/language/ControlPanel/
+\define config-title()
+$:/config/PageControlButtons/Visibility/$(listItem)$
+\end
+
+<<lingo Basics/Version/Prompt>> <<version>>
+
+<$set name="tv-config-toolbar-icons" value="yes">
+
+<$set name="tv-config-toolbar-text" value="yes">
+
+<$set name="tv-config-toolbar-class" value="">
+
+<$list filter="[all[shadows+tiddlers]tag[$:/tags/PageControls]!has[draft.of]]" variable="listItem">
+
+<div style="position:relative;">
+
+<$checkbox tiddler=<<config-title>> field="text" checked="show" unchecked="hide" default="show"/> <$transclude tiddler=<<listItem>>/> <i class="tc-muted"><$transclude tiddler=<<listItem>> field="description"/></i>
+
+</div>
+
+</$list>
+
+</$set>
+
+</$set>
+
+</$set>

--- a/esteren/tiddlers/Feond.tid
+++ b/esteren/tiddlers/Feond.tid
@@ -1,0 +1,13 @@
+book_0: p.13
+book_1: p.20, 26, 32, 34-39, 42, 57, 69, 74, 75, 83, 115, 151
+category: glossary
+created: 20150830173616127
+meaning: ennemi
+modified: 20150830180925691
+plural: feondas
+pronunciation: fé-onde
+tags: divers
+title: Feond
+type: text/vnd.tiddlywiki
+
+Créature hostile à l'humanité (feondas au pluriel) dont le nom signifie "ennemi" dans l'ancienne langue. De formes variées, les feondas peuvent être animaux, végétaux, voire un mélange improbable de plusieurs règnes naturels. Certains seraient même capables de posséder des cadavres ou des gens vivants.

--- a/esteren/tiddlers/Livre_1_–_Univers.tid
+++ b/esteren/tiddlers/Livre_1_–_Univers.tid
@@ -1,0 +1,7 @@
+category: book
+created: 20150830174753126
+modified: 20150830174825267
+tags: livres
+title: Livre 1 – Univers
+type: text/vnd.tiddlywiki
+

--- a/esteren/tiddlers/Sandbox_(Markdown).tid
+++ b/esteren/tiddlers/Sandbox_(Markdown).tid
@@ -1,6 +1,6 @@
 created: 20150829130239560
 field1: value1
-modified: 20150829221804344
+modified: 20150830164538142
 tags: Tag1 Tag2
 title: Sandbox (Markdown)
 type: text/x-markdown
@@ -13,3 +13,30 @@ This wiki **is** truely awesome.
  
 We're gonna make **huge** things with it.
 
+Les sauts à la ligne ne sont pas pris en compte.
+Ça continue à la suite dans un même paragraphe.
+
+Il y a deux syntaxes d'emphase, avec au choix le caractère `_` ou `*`. _Simple_ pour l'*italique*, __double__ pour le **gras**.
+
+    Un bloc de code se définit avec une indentation de 4 espaces.
+
+Exemple de [lien](http://tiddlywiki.com/) externe.
+
+> Une citation
+> 
+> Elle peut contenir plusieurs paragraphes
+>> avec plusieurs niveaux de citations
+> ## et des titres
+> * et des listes
+
+* Une liste non ordonnée
++ Plusieurs notations possibles
+  - indenter de 2 espaces pour faire des sous-items
+
+Une liste ordonnée utilise des chiffres suivis d'un point :
+
+2. Item
+  1. Sous-item
+8. L'ordre de la numérotation n'a pas d'importance
+
+* par contre, enchaîner des listes de nature différente n'est pas reconnu

--- a/esteren/tiddlers/Sandbox_(Markdown).tid
+++ b/esteren/tiddlers/Sandbox_(Markdown).tid
@@ -1,8 +1,8 @@
 created: 20150829130239560
 field1: value1
-modified: 20150829133302762
+modified: 20150829221804344
 tags: Tag1 Tag2
-title: Sandbox
+title: Sandbox (Markdown)
 type: text/x-markdown
 
 test: value

--- a/esteren/tiddlers/Sandbox_(WikiText).tid
+++ b/esteren/tiddlers/Sandbox_(WikiText).tid
@@ -1,0 +1,15 @@
+created: 20150829221807182
+field1: value1
+modified: 20150829221922398
+tags: Tag1 Tag2
+title: Sandbox (WikiText)
+type: text/vnd.tiddlywiki
+
+test: value
+
+! Title 1
+
+This wiki ''is'' truely awesome.
+
+We're gonna make ''huge'' things with it.
+

--- a/esteren/tiddlers/Sandbox_(WikiText).tid
+++ b/esteren/tiddlers/Sandbox_(WikiText).tid
@@ -1,6 +1,6 @@
 created: 20150829221807182
 field1: value1
-modified: 20150829221922398
+modified: 20150830164621146
 tags: Tag1 Tag2
 title: Sandbox (WikiText)
 type: text/vnd.tiddlywiki
@@ -12,4 +12,61 @@ test: value
 This wiki ''is'' truely awesome.
 
 We're gonna make ''huge'' things with it.
+
+---
+
+Les sauts à la ligne simples ne sont pas pris en compte. Ça continue à la suite dans un même paragraphe.<br>À moins d'utiliser une balise html `<br>`.
+
+Les syntaxes d'emphase sont spécifiques, une pour l'//italique// et une pour le ''gras''. On peut aussi __souligner__, ~~barrer~~, mettre en ^^exposant^^ ou en ,,indice,,.
+
+```
+Un bloc de code.
+```
+
+Exemple de [ext[lien|http://tiddlywiki.com/]] externe, ou [[interne|Sandbox (Markdown)]].
+
+> Une citation simple
+> Avec plusieurs paragraphes
+>> plusieurs niveaux
+>* des listes
+> mais pas de titres
+
+<<<
+Un bloc de citation
+
+Il peut contenir plusieurs paragraphes
+
+> avec plusieurs niveaux de citations
+
+!! et des titres
+
+* et des listes
+
+"""
+Et des syntaxes
+qui ne fonctionnent
+qu'en mode "bloc"
+"""
+<<< sans oublier l'auteur
+
+* Listes à puces
+** Sous-item
+# Liste ordonnée
+## Sous-item 1
+## Sous-item 2
+; Terme
+: Définition
+* On peut aussi
+*# mélanger
+*#; les types
+*# de listes,
+*#: à sa guise
+*> y compris
+*># avec des citations !
+
+|!Titre A|!Titre B|!Titre C|!Titre D|!Titre E|
+|A1|>|C1 : fusion horizontale à droite|D1 : fusion horizontale à gauche|<|
+| A2 centrée |>|C2 alignée à gauche | D2 alignée à droite|<|
+|A3 : fusion verticale|^B3 en haut|,C3 en bas|^ D3 en haut centrée |E3|
+|~|~|~|~|E4|
 

--- a/esteren/tiddlers/Tag1.tid
+++ b/esteren/tiddlers/Tag1.tid
@@ -1,0 +1,6 @@
+created: 20150829221542204
+modified: 20150829221542204
+tags: toc
+title: Tag1
+type: text/vnd.tiddlywiki
+

--- a/esteren/tiddlers/divers.tid
+++ b/esteren/tiddlers/divers.tid
@@ -1,0 +1,7 @@
+created: 20150830172340047
+modified: 20150830173827351
+tags: toc
+title: divers
+toc-link: no
+type: text/vnd.tiddlywiki
+


### PR DESCRIPTION
Includes:
- a button for creating a new term from a skeleton
- a data tiddler for the books
- display of glossary infos (pronunciation, plural, meaning) and books-and-pages references
- an example with the term "Feond"

Since the tools are also available from the page control buttons, I've put the "Tools" tab into the "More" tab, to gain place for more useful tabs on the sidebar.
