### PR TITLE
Glossary tids created will be markdown + UI test

### DIFF
--- a/esteren/tiddlers/$__.skeletons_glossary-term.tid
+++ b/esteren/tiddlers/$__.skeletons_glossary-term.tid
@@ -1,6 +1,6 @@
 category: glossary
 created: 20150830171647126
-modified: 20150830172355484
+modified: 20150918172213474
 title: $:/.skeletons/glossary-term
-type: text/vnd.tiddlywiki
+type: text/x-markdown
 

--- a/esteren/tiddlers/$__.stylesheets_glossary.tid
+++ b/esteren/tiddlers/$__.stylesheets_glossary.tid
@@ -1,0 +1,15 @@
+created: 20150830194003691
+modified: 20150830194338490
+tags: $:/tags/Stylesheet
+title: $:/.stylesheets/glossary
+type: text/vnd.tiddlywiki
+
+
+.ec-glossary-infos-box {
+	border: 1px solid <<colour message-border>>;
+	background: <<colour message-background>>;
+	padding: 0px 7px 0px 7px;
+	font-size: 12px;
+	line-height: 18px;
+	color: <<colour message-foreground>>;
+}

--- a/esteren/tiddlers/$__.ui_ViewTemplate_glossary-infos_1.tid
+++ b/esteren/tiddlers/$__.ui_ViewTemplate_glossary-infos_1.tid
@@ -1,0 +1,22 @@
+created: 20150830193603546
+list-before: $:/core/ui/ViewTemplate/subtitle
+modified: 20150830205321610
+tags: $:/tags/ViewTemplate
+title: $:/.ui/ViewTemplate/glossary-infos 1
+type: text/vnd.tiddlywiki
+
+<$list filter="[all[current]regexp:category[glossary]]">
+  <div class="ec-glossary-infos-box" style="float:right">
+"""
+    <$list filter="[all[current]has[pronunciation]]">
+      Prononciation : {{!!pronunciation}}
+    </$list>
+    <$list filter="[all[current]has[plural]]">
+      Pluriel : {{!!plural}}
+    </$list>
+    <$list filter="[all[current]has[meaning]]">
+      Signification en langue ancienne : {{!!meaning}}
+    </$list>
+"""
+  </div>
+</$list>

--- a/esteren/tiddlers/$__StoryList.tid
+++ b/esteren/tiddlers/$__StoryList.tid
@@ -1,5 +1,5 @@
-created: 20150830181650292
-list: 
+created: 20150918172258457
+list: [[Sandbox (Markdown)]]
 title: $:/StoryList
 type: text/vnd.tiddlywiki
 

--- a/esteren/tiddlers/Feond.tid
+++ b/esteren/tiddlers/Feond.tid
@@ -3,11 +3,11 @@ book_1: p.20, 26, 32, 34-39, 42, 57, 69, 74, 75, 83, 115, 151
 category: glossary
 created: 20150830173616127
 meaning: ennemi
-modified: 20150830180925691
+modified: 20150918172122857
 plural: feondas
 pronunciation: fé-onde
 tags: divers
 title: Feond
-type: text/vnd.tiddlywiki
+type: text/x-markdown
 
 Créature hostile à l'humanité (feondas au pluriel) dont le nom signifie "ennemi" dans l'ancienne langue. De formes variées, les feondas peuvent être animaux, végétaux, voire un mélange improbable de plusieurs règnes naturels. Certains seraient même capables de posséder des cadavres ou des gens vivants.

--- a/esteren/tiddlers/Livre_1_–_Univers.tid
+++ b/esteren/tiddlers/Livre_1_–_Univers.tid
@@ -1,7 +1,7 @@
 category: book
 created: 20150830174753126
-modified: 20150830174825267
+modified: 20150918172147105
 tags: livres
 title: Livre 1 – Univers
-type: text/vnd.tiddlywiki
+type: text/x-markdown
 

--- a/esteren/tiddlers/Sandbox_(Markdown).tid
+++ b/esteren/tiddlers/Sandbox_(Markdown).tid
@@ -1,6 +1,6 @@
 created: 20150829130239560
 field1: value1
-modified: 20150830164538142
+modified: 20150830202348244
 tags: Tag1 Tag2
 title: Sandbox (Markdown)
 type: text/x-markdown
@@ -20,7 +20,7 @@ Il y a deux syntaxes d'emphase, avec au choix le caractère `_` ou `*`. _Simple_
 
     Un bloc de code se définit avec une indentation de 4 espaces.
 
-Exemple de [lien](http://tiddlywiki.com/) externe.
+Exemple de [lien](http://tiddlywiki.com/) externe, ou [interne](#Sandbox (WikiText)).
 
 > Une citation
 > 


### PR DESCRIPTION
The button to create a new glossary item now generates markdown-type tiddlers.

Test for the presentation of pronunciation, meaning and ancient_tongue fields in a floating box (cohabits for the moment with the previous one, inline below the tags).
